### PR TITLE
[JT-B-J-028]

### DIFF
--- a/auth/src/main/java/com/jointAuth/util/JwtTokenUtils.java
+++ b/auth/src/main/java/com/jointAuth/util/JwtTokenUtils.java
@@ -42,7 +42,12 @@ public class JwtTokenUtils {
     }
 
     public String getFullName(String token) {
-        return getAllClaimsFromToken(token).getSubject();
+        if (token == null || token.isEmpty()) {
+            return null;
+        }
+
+        Claims claims = getAllClaimsFromToken(token);
+        return claims != null ? claims.getSubject() : null;
     }
 
     private Claims getAllClaimsFromToken(String token) {

--- a/auth/src/test/java/com/jointAuth/util/JwtTokenUtilsTest.java
+++ b/auth/src/test/java/com/jointAuth/util/JwtTokenUtilsTest.java
@@ -4,6 +4,7 @@ import com.jointAuth.model.User;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -73,5 +74,39 @@ public class JwtTokenUtilsTest {
         assertNotNull(exception);
     }
 
+
+    @Test
+    public void testGetFullNameSuccessful() {
+        Claims claims = Jwts.claims().setSubject("Vitally Novikov");
+
+        String token = Jwts.builder()
+                .setClaims(claims)
+                .signWith(io.jsonwebtoken.SignatureAlgorithm.HS256, secret)
+                .compact();
+
+        String fullName = jwtTokenUtils.getFullName(token);
+
+        assertEquals("Vitally Novikov", fullName);
+    }
+
+    @Test
+    public void testGetFullNameNullToken() {
+        String fullName = jwtTokenUtils.getFullName(null);
+
+        assertNull(fullName);
+    }
+
+    @Test
+    public void testGetFullNameInvalidToken() {
+        String invalidToken = "invalid.token.string";
+
+        String fullName = null;
+        try {
+            fullName = jwtTokenUtils.getFullName(invalidToken);
+            fail("Expected MalformedJwtException to be thrown");
+        } catch (MalformedJwtException e) {
+            assertNull(fullName);
+        }
+    }
 }
 


### PR DESCRIPTION
The method of extracting the full username from the token in utils has been modified. Unit tests for this method have also been added. Three cases are considered: 1) Successfully obtaining the full username.
2) Transfer to a null token.
3) Incorrect token format.